### PR TITLE
Consistently talk about parsing vectors instead of lists

### DIFF
--- a/src/error_recovery.md
+++ b/src/error_recovery.md
@@ -94,7 +94,7 @@ on Message::%done { print self; }
    We first the result of parsing for the first `Message` from `AB`, and
    encounter an error for the second element.
 
-   The error corresponds to parsing the list inside `Messages`. The grammar
+   The error corresponds to parsing the vector inside `Messages`. The grammar
    expects either `A` to start a new `Message`, or end of data to signal the end of
    the input; `1` matches neither so lookahead parsing fails.
    </details>
@@ -115,7 +115,7 @@ on Message::%done { print self; }
       ```
 
    b. Synchronize on `Message::a` in the _next message_, i.e., abandon parsing
-      the remaining fields in `Message` and start over. For that we would synchronize on the list elements in `Messages`,
+      the remaining fields in `Message` and start over. For that we would synchronize on the vector elements in `Messages`,
 
       ```spicy
       : (Message &synchronize)[];
@@ -135,12 +135,12 @@ on Message::%done { print self; }
 
    - If we synchronize on `Message::b` it would seem that we should be able to recover at its data.
 
-     This however does not work since the list uses lookahead parsing, so we
+     This however does not work since the vector uses lookahead parsing, so we
      would fail already in `Messages` before we could recover in `Message`.
 
-   - We need to synchronize on the next list element.
+   - We need to synchronize on the next vector element.
 
-     In larger units synchronizing high up (e.g., on a list in the top-level
+     In larger units synchronizing high up (e.g., on a vector in the top-level
      unit) allows recovering from more general errors at the cost of not
      extracting some data, e.g., we would be able to also handle misspelled `B`s
      in this example.

--- a/src/parsing_types.md
+++ b/src/parsing_types.md
@@ -14,19 +14,19 @@ types](https://docs.zeek.org/projects/spicy/en/latest/programming/parsing.html#p
 - [floating point
   numbers](https://docs.zeek.org/projects/spicy/en/latest/programming/parsing.html#real)
 - [regular expressions](https://docs.zeek.org/projects/spicy/en/latest/programming/parsing.html#regular-expression)
-- [lists](https://docs.zeek.org/projects/spicy/en/latest/programming/parsing.html#vector)
+- [vectors](https://docs.zeek.org/projects/spicy/en/latest/programming/parsing.html#vector)
 
 Fields not extracting any data can be marked `void`. They can still have hooks attached.
 
-Since they are pervasive we give a brief overview for lists here.
+Since they are pervasive we give a brief overview for vectors here.
 
-## Parsing lists
+## Parsing vectors
 
-A common requirement is to [parse lists of the same
+A common requirement is to [parse vector of the same
 type](https://docs.zeek.org/projects/spicy/en/latest/programming/parsing.html#vector),
 possibly of dynamic length.
 
-To parse a list of three integers we would write:
+To parse a vector of three integers we would write:
 
 ```spicy
 type X = unit {
@@ -44,33 +44,33 @@ type X = unit {
 };
 ```
 
-If the list is followed by e.g., a literal we can dynamically detect with
-lookahead parsing where the list ends. The literal does not need to be a
-field, but could also be in another parser following the list.
+If the vector is followed by e.g., a literal we can dynamically detect with
+lookahead parsing where the vector ends. The literal does not need to be a
+field, but could also be in another parser following the vector.
 
 ```spicy
 type X = unit {
     xs: uint16[];
-      : b"\x00"; # List is terminated with null byte.
+      : b"\x00"; # Vector is terminated with null byte.
 };
 ```
 
-If the terminator is in the domain of the list elements we can also use the
+If the terminator is in the domain of the vector elements we can also use the
 `&until` attribute.
 
 ```spicy
 type X = unit {
-    # List terminate with a null value
+    # Vector terminate with a null value
     xs: uint8[] &until=$$==0;
 };
 ```
 
-If the list elements require attributes themselves, we can pass them by grouping
+If the vector elements require attributes themselves, we can pass them by grouping
 them with the element type.
 
 ```spicy
 type X = unit {
-    # Parse a list of 4-byte integers less than 1024 until we find a null.
+    # Parse a vector of 4-byte integers less than 1024 until we find a null.
     xs: (uint64 &requires=$$<1024)[] &until=$$==0;
 };
 ```


### PR DESCRIPTION
Talking about parsing lists when we have a vector type is potentially confusing, especially since the docs also talk about parsing vectors.