### PR TITLE
Update zeek_protocol_analyzer_exercises.md

### DIFF
--- a/src/zeek_protocol_analyzer_exercises.md
+++ b/src/zeek_protocol_analyzer_exercises.md
@@ -3,7 +3,7 @@
 Starting from the default protocol analyzer template we want to (redundantly) pass the number of
 `bytes` for `Request` to Zeek as well.
 
-1. In the EVT file pass the number of `bytes` in `self.payload`.
+1. In the EVT file pass the number of `bytes` in request's `self.payload`.
 
    <details>
    <summary>Solution</summary>


### PR DESCRIPTION
Specify the payload length is to be passed to the request (not to the reply).